### PR TITLE
修复因无 tracker 属性而运行失败

### DIFF
--- a/U2TrackerUpdater-python2.py
+++ b/U2TrackerUpdater-python2.py
@@ -152,7 +152,7 @@ def c_Tr():
     tc = transmissionrpc.Client(transmission_config['host'], port=transmission_config['port'], user=transmission_config['username'], password=transmission_config['password'])
 
     def get_u2_torrents_hash():
-        torrents = list(filter(lambda x: 'dmhy' in x.trackers[0]['announce'], tc.get_torrents()))
+        torrents = list(filter(lambda x: x.trackers and 'dmhy' in x.trackers[0]['announce'], tc.get_torrents()))
 
         u2_torrent_info_hash = []
         for torrent in torrents:

--- a/U2TrackerUpdater.py
+++ b/U2TrackerUpdater.py
@@ -169,7 +169,7 @@ def c_Tr():
     tc = transmissionrpc.Client(transmission_config['host'], port=transmission_config['port'], user=transmission_config['username'], password=transmission_config['password'])
 
     def get_u2_torrents_hash():
-        torrents = list(filter(lambda x: 'dmhy' in x.trackers[0]['announce'], tc.get_torrents()))
+        torrents = list(filter(lambda x: x.trackers and 'dmhy' in x.trackers[0]['announce'], tc.get_torrents()))
 
         u2_torrent_info_hash = []
         for torrent in torrents:


### PR DESCRIPTION
当 transmission 中有 magnet 添加的任务时，任务无 tracker 属性，运行会失败。
针对该问题，加了个 trackers 的非空判断