### PR TITLE
fix Transmission Client initialisation

### DIFF
--- a/U2TrackerUpdater.py
+++ b/U2TrackerUpdater.py
@@ -208,7 +208,7 @@ class Transmission(BtClient):
         self.password = input("输入客户端密码：")
 
         print("开始连接 Transmission 客户端...")
-        tc = transmission_rpc.Client(self.host, port=self.port, username=self.user, password=self.password)
+        tc = transmission_rpc.Client(host=self.host, port=self.port, username=self.user, password=self.password)
         self.tc = tc
 
     def getAllTorrentHashes(self) -> list:


### PR DESCRIPTION
你好 @LoidVC 

感谢你接受的我的pull request，在 #6 中的代码还更改了 `host=...`。或许你在merge其他代码的时候忽略了这一改动。

如果没有这个改动，Python会报错：

```
    tc = transmission_rpc.Client(self.host, port=self.port, username=self.user, password=self.password)
TypeError: __init__() takes 1 positional argument but 2 positional arguments (and 3 keyword-only arguments) were given
```