### PR TITLE
增加 DelugeWebAPI, ruTorrent 支持

### DIFF
--- a/U2TrackerUpdater.py
+++ b/U2TrackerUpdater.py
@@ -49,7 +49,6 @@ notes = """
 # 4.执行脚本的主机和运行客户端的主机在同一局域网即可，客户端地址写运行客户端的主机的地址
 """
 
-
 # 和U2的jsonrpc交互部分
 
 endpoint = "https://u2.dmhy.org/jsonrpc_torrentkey.php"
@@ -162,13 +161,13 @@ class BtClient(object):
 class QBittorrent(BtClient):
     def __init__(self):
         super().__init__()
-        self.host = input("输入客户端地址（http://IP:端口）：")
-        self.user = input("输入客户端用户名：")
-        self.password = input("输入客户端密码：")
+        host = input("输入客户端地址（http://IP:端口）：")
+        user = input("输入客户端用户名：")
+        password = input("输入客户端密码：")
 
-        qb = QbittorrentClient(self.host)
+        qb = QbittorrentClient(host)
         print("开始连接 Qbittorrent 客户端...")
-        qb.login(self.user, self.password)
+        qb.login(user, password)
         self.qb = qb
 
     def getAllTorrentHashes(self) -> list:
@@ -206,14 +205,13 @@ class Transmission(BtClient):
 
     def __init__(self):
         super().__init__()
-        self.host = input("输入客户端IP：")
-        self.port = input("输入客户端端口（通常为9091）：")
-        self.user = input("输入客户端用户名：")
-        self.password = input("输入客户端密码：")
+        host = input("输入客户端IP：")
+        port = input("输入客户端端口（通常为9091）：")
+        user = input("输入客户端用户名：")
+        password = input("输入客户端密码：")
 
         print("开始连接 Transmission 客户端...")
-        tc = transmission_rpc.Client(host=self.host, port=self.port, username=self.user, password=self.password)
-        self.tc = tc
+        self.tc = transmission_rpc.Client(host=host, port=int(port), username=user, password=password)
 
     def getAllTorrentHashes(self) -> list:
         torrents = list(filter(lambda x: x.trackers and 'dmhy' in x.trackers[0]['announce'], self.tc.get_torrents()))
@@ -230,10 +228,10 @@ class Transmission(BtClient):
         return self.tc.change_torrent(info["id"], trackerReplace=(0, to_tracker.format(item["result"])))
 
 
-class Deluge(BtClient):
+class DelugeRPC(BtClient):
     def __init__(self):
         super().__init__()
-        __DE_URL__ = input("输入客户端IP（http://IP）：")
+        __DE_URL__ = input("输入客户端IP：")
         __DE_PORT__ = int(input("输入客户端后端端口（非WebUI端口）："))
         __DE_USER__ = input("输入客户端用户名：")
         __DE_PW__ = input("输入客户端密码：")
@@ -245,13 +243,68 @@ class Deluge(BtClient):
     def getAllTorrentHashes(self) -> list:
         print("Fetching DMHY torrents from Deluge...")
         torrent_list = self.client.core.get_torrents_status({}, ['trackers'])
-        return [{"hash": str(hash_)[2:-1], "raw_hash": hash_} for hash_ in torrent_list if
-                "dmhy" in str(torrent_list[hash_][b'trackers'][0][b'url'])]
+        return [
+            {"hash": str(hash_)[2:-1], "raw_hash": hash_}
+            for hash_ in torrent_list
+            if any([tracker in str(torrent_list[hash_][b'trackers'][0][b'url']) for tracker in u2_tracker])
+        ]
 
     def changeTorrentTracker(self, info, item):
         self.client.core.set_torrent_trackers(info["raw_hash"], [
             {'url': to_tracker.format(item["result"]), 'tier': 0}
         ])
+
+
+class DelugeWebApi(BtClient):
+    id_ = 0
+
+    sess = None
+
+    def __init__(self):
+        print("本方法是以WEB API的形式连接Deluge客户端，如果你选择想以RPC API的形式连接。请退出重新选择 3: Deluge")
+        super().__init__()
+
+        self.host = input("输入客户端地址（http://IP:端口）：")
+        password = input("输入客户端密码：")
+
+        print("开始连接 Deluge 客户端...")
+        login_json = self.webApiRequest('auth.login', [password])
+        try:
+            assert login_json['result'] is True
+        except Exception:
+            print('登录错误，请检查客户端地址和密码是否正确')
+            exit()
+
+    def webApiRequest(self, method, params):
+        if not self.sess:
+            self.sess = requests.Session()
+
+        self.id_ += 1
+
+        try:
+            req = self.sess.post("{}/json".format(self.host), json={
+                'method': method,
+                'params': params,
+                'id': self.id_
+            })
+            return req.json()
+        except Exception:
+            return {}
+
+    def getAllTorrentHashes(self) -> list:
+        res = self.webApiRequest('core.get_torrents_status', [{}, [
+            "trackers"
+        ]])
+        torrent_list = res.get('result', [])
+
+        return [{"hash": hash_} for (hash_, details) in torrent_list.items() if
+                any([tracker in torrent_list[hash_]['trackers'][0]['url'] for tracker in u2_tracker])]
+
+    def changeTorrentTracker(self, info, item):
+        self.webApiRequest('core.set_torrent_trackers', [info['hash'], [{
+            'tier': 0,
+            'url': to_tracker.format(item["result"])
+        }]])
 
 
 if __name__ == '__main__':
@@ -263,13 +316,15 @@ if __name__ == '__main__':
 
     # 客户端类型
     client = None
-    clientType = input('当前客户端类型（1:qBittorrent,2:Transmission,3:Deluge）:')
+    clientType = input('请输入客户端类型：\n1:qBittorrent, 2:Transmission, 3:Deluge (RPC API), 4:Deluge (Web API)：')
     if clientType == '1':
         client = QBittorrent()
     elif clientType == '2':
         client = Transmission()
     elif clientType == '3':
-        client = Deluge()
+        client = DelugeRPC()
+    elif clientType == '4':
+        client = DelugeWebApi()
     else:
         exit()
 


### PR DESCRIPTION
1. 增加DelugeWebAPI方法，原Deluge方法重命名为 DelugeRPC
2. 对原先 DelugeRPC 的tracker地址判断进一步限定。不过 DelugeRPC 和 DelugeWebAPI 目前均只判断了tier[0]中的tracker地址是否符合要求，对于多tier的情况没有考虑，不过对于u2的种子来说足够了。
3. 移除Qbt和Tr中不需要放入对象属性的username,port,host,password
4. 增加ruTorrent的支持，同样也只判断了 tier[0] 。 ruTorrent的具体交互方法从 topicid=12715 抄的，仅作了py下的改写。~~（ruTorrent不等同于rTorrent，大雾）~~

refs:  

- topicid=12701&page=p139746#pid139746
- topicid=12689&page=p139773#pid139773
- topicid=12715